### PR TITLE
#136 - Add new HAL links "lux:itemCurrentHierarchyPage" and "lux:setC…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Enabled using pageWith parameter for search ([#133](https://github.com/project-lux/lux-middletier/issues/133)).
 - Change "lux:setItemsWithImages" so that users don't see the check for archive classification ([#87](https://github.com/project-lux/lux-middletier/issues/87)).
 - Replace "lux:setIncludedItems" and "lux:setIncludedSets" HAL links with "lux:objectOrSetMemberOfSet" ([#135](https://github.com/project-lux/lux-middletier/pull/135)).
+- Add new HAL links "lux:itemCurrentHierarchyPage" and "lux:setCurrentHierarchyPage" so that the front end can get the current page of hierarchy results. ([#136](https://github.com/project-lux/lux-middletier/pull/136)).
 
 ## 1.2.4
 - Fixed lux:setUnit HAL link ([#128](https://github.com/project-lux/lux-middletier/issues/128)).

--- a/lib/build-query/builder.js
+++ b/lib/build-query/builder.js
@@ -78,6 +78,7 @@ const keyFuncNameMap = {
   },
   item: {
     'lux:itemArchive': queries.archivesWithItem.name,
+    'lux:itemCurrentHierarchyPage': queries.currentItemAndSiblings.name,
     'lux:itemEvents': queries.eventsWithItem.name,
     'lux:itemDepartment': queries.departmentsWithItem.name,
     'lux:itemUnit': queries.itemById.name,
@@ -103,6 +104,7 @@ const keyFuncNameMap = {
     'lux:placeWorkTypes': queries.worksRelatedToPlace.name,
   },
   set: {
+    'lux:setCurrentHierarchyPage': queries.currentSetAndSiblings.name,
     'lux:setDepartment': queries.departmentsCuratedSet.name,
     'lux:setEvents': queries.eventsWithSet.name,
     'lux:objectOrSetMemberOfSet': queries.itemsOrSetsMemberOfSet.name,
@@ -337,6 +339,10 @@ const queryBuilders = {
     const q = prepareQuery(queries.archivesWithItem(id))
     return `${config.searchUriHost}/api/search/set?q=${q}`
   },
+  'lux:itemCurrentHierarchyPage': (id) => {
+    const q = prepareQuery(queries.currentItemAndSiblings(id))
+    return `${config.searchUriHost}/api/search/multi?q=${q}&sort=archiveSortId:asc&pageWith=${encodeURIComponent(id)}`
+  },
   'lux:itemEvents': (id) => {
     const q = prepareQuery(queries.eventsWithItem(id))
     return `${config.searchUriHost}/api/search/event?q=${q}&sort=eventStartDate:asc`
@@ -432,6 +438,10 @@ const queryBuilders = {
   'lux:placeWorkTypes': (id) => {
     const q = prepareQuery(queries.worksRelatedToPlace(id))
     return `${config.searchUriHost}/api/facets/work?q=${q}&name=workTypeId`
+  },
+  'lux:setCurrentHierarchyPage': (id) => {
+    const q = prepareQuery(queries.currentSetAndSiblings(id))
+    return `${config.searchUriHost}/api/search/multi?q=${q}&sort=archiveSortId:asc&pageWith=${encodeURIComponent(id)}`
   },
   'lux:setDepartment': (id) => {
     const q = prepareQuery(queries.departmentsCuratedSet(id))

--- a/lib/build-query/queries.js
+++ b/lib/build-query/queries.js
@@ -21,6 +21,8 @@ import conceptsRelatedToConcept from './queries/conceptsRelatedToConcept.js'
 import conceptsRelatedToEvent from './queries/conceptsRelatedToEvent.js'
 import conceptsRelatedToPlace from './queries/conceptsRelatedToPlace.js'
 import conceptsSubjectsForPeriod from './queries/conceptsSubjectsForPeriod.js'
+import currentItemAndSiblings from './queries/currentItemAndSiblings.js'
+import currentSetAndSiblings from './queries/currentSetAndSiblings.js'
 import departmentsCuratedSet from './queries/departmentsCuratedSet.js'
 import departmentsWithItem from './queries/departmentsWithItem.js'
 import eventsCarriedOutByAgent from './queries/eventsCarriedOutByAgent.js'
@@ -91,6 +93,8 @@ const queries = {
   conceptsRelatedToEvent,
   conceptsRelatedToPlace,
   conceptsSubjectsForPeriod,
+  currentItemAndSiblings,
+  currentSetAndSiblings,
   departmentsCuratedSet,
   departmentsWithItem,
   eventsCarriedOutByAgent,

--- a/lib/build-query/queries/currentItemAndSiblings.js
+++ b/lib/build-query/queries/currentItemAndSiblings.js
@@ -1,0 +1,42 @@
+// Get the current item and its siblings in an archive hierarchy.
+const currentItemAndSiblings = (itemId) => ({
+  _scope: "multi",
+  OR: [
+    {
+      _scope: "item",
+      memberOf: {
+        AND: [
+          {
+            classification: {
+              identifier: "http://vocab.getty.edu/aat/300375748",
+            },
+          },
+          {
+            containingItem: {
+              id: itemId,
+            },
+          },
+        ],
+      },
+    },
+    {
+      _scope: "set",
+      memberOf: {
+        AND: [
+          {
+            classification: {
+              identifier: "http://vocab.getty.edu/aat/300375748",
+            },
+          },
+          {
+            containingItem: {
+              id: itemId,
+            },
+          },
+        ],
+      },
+    },
+  ],
+});
+
+export default currentItemAndSiblings;

--- a/lib/build-query/queries/currentSetAndSiblings.js
+++ b/lib/build-query/queries/currentSetAndSiblings.js
@@ -1,0 +1,42 @@
+// Get the current set and its siblings in an archive hierarchy.
+const currentSetAndSiblings = (setId) => ({
+    _scope: "multi",
+    OR: [
+      {
+        _scope: "item",
+        memberOf: {
+          AND: [
+            {
+              classification: {
+                identifier: "http://vocab.getty.edu/aat/300375748",
+              },
+            },
+            {
+              containingSet: {
+                id: setId,
+              },
+            },
+          ],
+        },
+      },
+      {
+        _scope: "set",
+        memberOf: {
+          AND: [
+            {
+              classification: {
+                identifier: "http://vocab.getty.edu/aat/300375748",
+              },
+            },
+            {
+              containingSet: {
+                id: setId,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+  
+  export default currentSetAndSiblings;


### PR DESCRIPTION
…urrentHierarchyPage" so that the front end can get the current page of hierarchy results.