### PR TITLE
Introduces second ML proxy for Document CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Changelog
 
-## Marklogic Dependencies
+## MarkLogic Dependencies
 
-- With v1.2.5 Marklogic client code was regenerated against ML v1.36.0 dated 03/11/25
-- With v1.1.18 Marklogic client code was regenerated against ML v1.25.0 dated 09/23/24
-- With v1.1.12, Marklogic client code was regenerated against ML v1.20.0 dated 07/08/24
-- With v1.1.4, Marklogic client code was regenerated against ML v1.11.0 dated 03/04/23
-- With v1.1.0, Marklogic client code was regenerated against ML v1.6.0 dated 11/21/23
+- With v1.2.9 MarkLogic client code was regenerated against ML v1.39.0 dated 05/05/25
+- With v1.2.5 MarkLogic client code was regenerated against ML v1.36.0 dated 03/11/25
+- With v1.1.18 MarkLogic client code was regenerated against ML v1.25.0 dated 09/23/24
+- With v1.1.12, MarkLogic client code was regenerated against ML v1.20.0 dated 07/08/24
+- With v1.1.4, MarkLogic client code was regenerated against ML v1.11.0 dated 03/04/23
+- With v1.1.0, MarkLogic client code was regenerated against ML v1.6.0 dated 11/21/23
 - With v0.5.0, MarkLogic client code was regenerated against ML v1.0.17 dated 5/30/23.
 
 ---
+## 1.2.9
+- Changed path to backend Read Document endpoint ([#163](https://github.com/project-lux/lux-middletier/issues/163)).
+
 ## 1.2.8
 - Added HAL links for Collection tabs and accordions on Place pages ([#142](https://github.com/project-lux/lux-middletier/issues/142)).
 - Added HAL links for Collection tabs and accordions on Event pages ([#143](https://github.com/project-lux/lux-middletier/issues/143)).
@@ -85,7 +89,7 @@
 
 - Add parameters for 'page', 'pageLength', and 'sort' to the facets endpoint. (#65)
 - Update gulpfile to handle new MarkLogic repo structure.
-- Regenerate Marklogic client code, which allows for new facets parameters, and removes personRoles endpoint
+- Regenerate MarkLogic client code, which allows for new facets parameters, and removes personRoles endpoint
 
 ## 1.1.11
 
@@ -162,7 +166,7 @@
 ## 0.5.2
 
 - Added HAL link lux:setIncludedWorks (#75).
-- Added Support For Multiple Marklogic Proxies, send facet-only searches to the second app server port (#90).
+- Added Support For Multiple MarkLogic Proxies, send facet-only searches to the second app server port (#90).
 
 ## 0.5.1
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,8 +5,13 @@ import { generate } from 'marklogic/lib/proxy-generator.js'
 import rename from 'gulp-rename'
 
 function proxygen() {
+  gulp
+    .src('../lux-marklogic/src/main/ml-modules/root/ds/lux')
+    .pipe(generate())
+    .pipe(rename({ extname: '.cjs' }))
+    .pipe(gulp.dest('lib/ml-generated'))
   return gulp
-    .src('../lux-marklogic/src/main/ml-modules/root/ds/*')
+    .src('../lux-marklogic/src/main/ml-modules/root/ds/lux/document')
     .pipe(generate())
     .pipe(rename({ extname: '.cjs' }))
     .pipe(gulp.dest('lib/ml-generated'))

--- a/lib/ml-generated/document.cjs
+++ b/lib/ml-generated/document.cjs
@@ -26,7 +26,7 @@ class Document {
     if (serviceDeclaration === undefined || serviceDeclaration === null) {
       serviceDeclaration = {
         "endpointDirectory": "/ds/lux/document",
-        "$javaClass": "edu.yale.collections.lux.marklogic.DocumentServices"
+        "$javaClass": "edu.yale.collections.lux.marklogic.services.Document"
       };
     }
     this.$mlProxy = client.createProxy(serviceDeclaration).withFunction({

--- a/lib/ml-generated/document.cjs
+++ b/lib/ml-generated/document.cjs
@@ -1,0 +1,225 @@
+// GENERATED - DO NOT EDIT!
+"use strict";
+/**
+* Provides a set of operations on the database server
+*/
+class Document {
+  /**
+  * A convenience factory that calls the constructor to create the Document object for executing operations
+  * on the database server.
+  * @param {DatabaseClient} client - the client for accessing the database server as the user
+  * @param {object} [serviceDeclaration] - an optional declaration for a custom implementation of the service
+  * @returns {Document} the object for the database operations
+  */
+  static on(client, serviceDeclaration) {
+    return new Document(client, serviceDeclaration);
+  }
+  /**
+  * The constructor for creating a Document object for executing operations on the database server.
+  * @param {DatabaseClient} client - the client for accessing the database server as the user
+  * @param {object} [serviceDeclaration] - an optional declaration for a custom implementation of the service
+  */
+  constructor(client, serviceDeclaration) {
+    if (client === undefined || client === null) {
+      throw new Error("missing required client");
+    }
+    if (serviceDeclaration === undefined || serviceDeclaration === null) {
+      serviceDeclaration = {
+        "endpointDirectory": "/ds/lux/document",
+        "$javaClass": "edu.yale.collections.lux.marklogic.DocumentServices"
+      };
+    }
+    this.$mlProxy = client.createProxy(serviceDeclaration).withFunction({
+      "functionName": "create",
+      "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }, {
+        "name": "doc",
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
+        "dataKind": "node",
+        "mimeType": "application/json",
+        "multiple": false,
+        "nullable": false
+      }, {
+        "name": "lang",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }],
+      "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
+        "dataKind": "node",
+        "mimeType": "application/json",
+        "multiple": false,
+        "nullable": false
+      },
+      "maxArgs": 3,
+      "paramsKind": "multiNode",
+      "sessionParam": null,
+      "returnKind": "single",
+      "$jsOutputMode": "promise"
+    }, ".mjs").withFunction({
+      "functionName": "delete",
+      "params": [{
+        "name": "uri",
+        "datatype": "string",
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false,
+        "nullable": false
+      }],
+      "maxArgs": 1,
+      "paramsKind": "multiAtomic",
+      "sessionParam": null,
+      "return": null,
+      "returnKind": "empty",
+      "$jsOutputMode": "promise"
+    }, ".mjs").withFunction({
+      "functionName": "read",
+      "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }, {
+        "name": "uri",
+        "datatype": "string",
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false,
+        "nullable": false
+      }, {
+        "name": "profile",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }, {
+        "name": "lang",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }],
+      "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
+        "dataKind": "node",
+        "mimeType": "application/json",
+        "multiple": false,
+        "nullable": false
+      },
+      "maxArgs": 4,
+      "paramsKind": "multiAtomic",
+      "sessionParam": null,
+      "returnKind": "single",
+      "$jsOutputMode": "promise"
+    }, ".mjs").withFunction({
+      "functionName": "update",
+      "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }, {
+        "name": "doc",
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
+        "dataKind": "node",
+        "mimeType": "application/json",
+        "multiple": false,
+        "nullable": false
+      }, {
+        "name": "lang",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }],
+      "return": {
+        "datatype": "jsonDocument",
+        "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
+        "dataKind": "node",
+        "mimeType": "application/json",
+        "multiple": false,
+        "nullable": false
+      },
+      "maxArgs": 3,
+      "paramsKind": "multiNode",
+      "sessionParam": null,
+      "returnKind": "single",
+      "$jsOutputMode": "promise"
+    }, ".mjs");
+  }
+  /**
+  * Invokes the create operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype,
+  * @param {array|Buffer|Map|Set|stream.Readable|string} doc - provides an input value of the jsonDocument datatype,
+  * @param {string} [lang] - provides an input value of the string datatype
+  * @returns {Promise} object value of the jsonDocument data type
+  */
+  create(unitName, doc, lang) {
+    return this.$mlProxy.execute("create", {
+      "unitName": unitName,
+      "doc": doc,
+      "lang": lang
+    }, arguments.length);
+  }
+  /**
+  * Invokes the delete operation on the database server.
+  * @param {string} uri - provides an input value of the string datatype
+  * @returns {Promise} for success or failure
+  */
+  delete(uri) {
+    return this.$mlProxy.execute("delete", {
+      "uri": uri
+    }, arguments.length);
+  }
+  /**
+  * Invokes the read operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype,
+  * @param {string} uri - provides an input value of the string datatype,
+  * @param {string} [profile] - provides an input value of the string datatype,
+  * @param {string} [lang] - provides an input value of the string datatype
+  * @returns {Promise} object value of the jsonDocument data type
+  */
+  read(unitName, uri, profile, lang) {
+    return this.$mlProxy.execute("read", {
+      "unitName": unitName,
+      "uri": uri,
+      "profile": profile,
+      "lang": lang
+    }, arguments.length);
+  }
+  /**
+  * Invokes the update operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype,
+  * @param {array|Buffer|Map|Set|stream.Readable|string} doc - provides an input value of the jsonDocument datatype,
+  * @param {string} [lang] - provides an input value of the string datatype
+  * @returns {Promise} object value of the jsonDocument data type
+  */
+  update(unitName, doc, lang) {
+    return this.$mlProxy.execute("update", {
+      "unitName": unitName,
+      "doc": doc,
+      "lang": lang
+    }, arguments.length);
+  }
+}
+module.exports = Document;

--- a/lib/ml-generated/lux.cjs
+++ b/lib/ml-generated/lux.cjs
@@ -26,7 +26,7 @@ class Lux {
     if (serviceDeclaration === undefined || serviceDeclaration === null) {
       serviceDeclaration = {
         "endpointDirectory": "/ds/lux",
-        "$javaClass": "edu.yale.collections.lux.marklogic.RootServices"
+        "$javaClass": "edu.yale.collections.lux.marklogic.services.Root"
       };
     }
     this.$mlProxy = client.createProxy(serviceDeclaration).withFunction({

--- a/lib/ml-generated/lux.cjs
+++ b/lib/ml-generated/lux.cjs
@@ -26,12 +26,19 @@ class Lux {
     if (serviceDeclaration === undefined || serviceDeclaration === null) {
       serviceDeclaration = {
         "endpointDirectory": "/ds/lux",
-        "$javaClass": "com.marklogic.example.Lux"
+        "$javaClass": "edu.yale.collections.lux.marklogic.RootServices"
       };
     }
     this.$mlProxy = client.createProxy(serviceDeclaration).withFunction({
       "functionName": "advancedSearchConfig",
-      "params": [],
+      "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }],
       "return": {
         "datatype": "jsonDocument",
         "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
@@ -40,13 +47,21 @@ class Lux {
         "multiple": false,
         "nullable": false
       },
-      "paramsKind": "empty",
+      "maxArgs": 1,
+      "paramsKind": "multiAtomic",
       "sessionParam": null,
       "returnKind": "single",
       "$jsOutputMode": "promise"
     }, ".mjs").withFunction({
       "functionName": "autoComplete",
       "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }, {
         "name": "text",
         "datatype": "string",
         "dataKind": "atomic",
@@ -125,44 +140,7 @@ class Lux {
         "multiple": false,
         "nullable": false
       },
-      "maxArgs": 10,
-      "paramsKind": "multiAtomic",
-      "sessionParam": null,
-      "returnKind": "single",
-      "$jsOutputMode": "promise"
-    }, ".mjs").withFunction({
-      "functionName": "document",
-      "params": [{
-        "name": "uri",
-        "datatype": "string",
-        "dataKind": "atomic",
-        "mimeType": "text/plain",
-        "multiple": false,
-        "nullable": false
-      }, {
-        "name": "profile",
-        "datatype": "string",
-        "nullable": true,
-        "dataKind": "atomic",
-        "mimeType": "text/plain",
-        "multiple": false
-      }, {
-        "name": "lang",
-        "datatype": "string",
-        "nullable": true,
-        "dataKind": "atomic",
-        "mimeType": "text/plain",
-        "multiple": false
-      }],
-      "return": {
-        "datatype": "jsonDocument",
-        "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
-        "dataKind": "node",
-        "mimeType": "application/json",
-        "multiple": false,
-        "nullable": false
-      },
-      "maxArgs": 3,
+      "maxArgs": 11,
       "paramsKind": "multiAtomic",
       "sessionParam": null,
       "returnKind": "single",
@@ -170,6 +148,13 @@ class Lux {
     }, ".mjs").withFunction({
       "functionName": "facets",
       "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }, {
         "name": "name",
         "datatype": "string",
         "dataKind": "atomic",
@@ -220,7 +205,7 @@ class Lux {
         "multiple": false,
         "nullable": false
       },
-      "maxArgs": 6,
+      "maxArgs": 7,
       "paramsKind": "multiAtomic",
       "sessionParam": null,
       "returnKind": "single",
@@ -228,6 +213,13 @@ class Lux {
     }, ".mjs").withFunction({
       "functionName": "relatedList",
       "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }, {
         "name": "scope",
         "datatype": "string",
         "dataKind": "atomic",
@@ -285,7 +277,7 @@ class Lux {
         "multiple": false,
         "nullable": false
       },
-      "maxArgs": 7,
+      "maxArgs": 8,
       "paramsKind": "multiAtomic",
       "sessionParam": null,
       "returnKind": "single",
@@ -293,6 +285,13 @@ class Lux {
     }, ".mjs").withFunction({
       "functionName": "search",
       "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }, {
         "name": "q",
         "datatype": "string",
         "dataKind": "atomic",
@@ -371,7 +370,7 @@ class Lux {
         "multiple": false,
         "nullable": false
       },
-      "maxArgs": 10,
+      "maxArgs": 11,
       "paramsKind": "multiAtomic",
       "sessionParam": null,
       "returnKind": "single",
@@ -379,6 +378,13 @@ class Lux {
     }, ".mjs").withFunction({
       "functionName": "searchEstimate",
       "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }, {
         "name": "q",
         "datatype": "jsonDocument",
         "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
@@ -402,14 +408,21 @@ class Lux {
         "multiple": false,
         "nullable": false
       },
-      "maxArgs": 2,
+      "maxArgs": 3,
       "paramsKind": "multiNode",
       "sessionParam": null,
       "returnKind": "single",
       "$jsOutputMode": "promise"
     }, ".mjs").withFunction({
       "functionName": "searchInfo",
-      "params": [],
+      "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }],
       "return": {
         "datatype": "jsonDocument",
         "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
@@ -418,13 +431,21 @@ class Lux {
         "multiple": false,
         "nullable": false
       },
-      "paramsKind": "empty",
+      "maxArgs": 1,
+      "paramsKind": "multiAtomic",
       "sessionParam": null,
       "returnKind": "single",
       "$jsOutputMode": "promise"
     }, ".mjs").withFunction({
       "functionName": "searchWillMatch",
       "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }, {
         "name": "q",
         "datatype": "jsonDocument",
         "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
@@ -441,14 +462,21 @@ class Lux {
         "multiple": false,
         "nullable": false
       },
-      "maxArgs": 1,
+      "maxArgs": 2,
       "paramsKind": "multiNode",
       "sessionParam": null,
       "returnKind": "single",
       "$jsOutputMode": "promise"
     }, ".mjs").withFunction({
       "functionName": "stats",
-      "params": [],
+      "params": [{
+        "name": "unitName",
+        "datatype": "string",
+        "nullable": true,
+        "dataKind": "atomic",
+        "mimeType": "text/plain",
+        "multiple": false
+      }],
       "return": {
         "datatype": "jsonDocument",
         "$javaClass": "com.fasterxml.jackson.databind.JsonNode",
@@ -457,7 +485,8 @@ class Lux {
         "multiple": false,
         "nullable": false
       },
-      "paramsKind": "empty",
+      "maxArgs": 1,
+      "paramsKind": "multiAtomic",
       "sessionParam": null,
       "returnKind": "single",
       "$jsOutputMode": "promise"
@@ -525,13 +554,17 @@ class Lux {
   }
   /**
   * Invokes the advancedSearchConfig operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype
   * @returns {Promise} object value of the jsonDocument data type
   */
-  advancedSearchConfig() {
-    return this.$mlProxy.execute("advancedSearchConfig", {}, arguments.length);
+  advancedSearchConfig(unitName) {
+    return this.$mlProxy.execute("advancedSearchConfig", {
+      "unitName": unitName
+    }, arguments.length);
   }
   /**
   * Invokes the autoComplete operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype,
   * @param {string} text - provides an input value of the string datatype,
   * @param {string} context - provides an input value of the string datatype,
   * @param {boolean|string} [fullyHonorContext] - provides an input value of the boolean datatype,
@@ -544,8 +577,9 @@ class Lux {
   * @param {number|string} [timeoutInMilliseconds] - provides an input value of the int datatype
   * @returns {Promise} object value of the jsonDocument data type
   */
-  autoComplete(text, context, fullyHonorContext, onlyMatchOnPrimaryNames, onlyReturnPrimaryNames, page, pageLength, filterIndex, previouslyFiltered, timeoutInMilliseconds) {
+  autoComplete(unitName, text, context, fullyHonorContext, onlyMatchOnPrimaryNames, onlyReturnPrimaryNames, page, pageLength, filterIndex, previouslyFiltered, timeoutInMilliseconds) {
     return this.$mlProxy.execute("autoComplete", {
+      "unitName": unitName,
       "text": text,
       "context": context,
       "fullyHonorContext": fullyHonorContext,
@@ -559,21 +593,8 @@ class Lux {
     }, arguments.length);
   }
   /**
-  * Invokes the document operation on the database server.
-  * @param {string} uri - provides an input value of the string datatype,
-  * @param {string} [profile] - provides an input value of the string datatype,
-  * @param {string} [lang] - provides an input value of the string datatype
-  * @returns {Promise} object value of the jsonDocument data type
-  */
-  document(uri, profile, lang) {
-    return this.$mlProxy.execute("document", {
-      "uri": uri,
-      "profile": profile,
-      "lang": lang
-    }, arguments.length);
-  }
-  /**
   * Invokes the facets operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype,
   * @param {string} name - provides an input value of the string datatype,
   * @param {string} q - provides an input value of the string datatype,
   * @param {string} [scope] - provides an input value of the string datatype,
@@ -582,8 +603,9 @@ class Lux {
   * @param {string} [sort] - provides an input value of the string datatype
   * @returns {Promise} object value of the jsonDocument data type
   */
-  facets(name, q, scope, page, pageLength, sort) {
+  facets(unitName, name, q, scope, page, pageLength, sort) {
     return this.$mlProxy.execute("facets", {
+      "unitName": unitName,
       "name": name,
       "q": q,
       "scope": scope,
@@ -594,6 +616,7 @@ class Lux {
   }
   /**
   * Invokes the relatedList operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype,
   * @param {string} scope - provides an input value of the string datatype,
   * @param {string} name - provides an input value of the string datatype,
   * @param {string} uri - provides an input value of the string datatype,
@@ -603,8 +626,9 @@ class Lux {
   * @param {number|string} [relationshipsPerRelation] - provides an input value of the int datatype
   * @returns {Promise} object value of the jsonDocument data type
   */
-  relatedList(scope, name, uri, page, pageLength, filterResults, relationshipsPerRelation) {
+  relatedList(unitName, scope, name, uri, page, pageLength, filterResults, relationshipsPerRelation) {
     return this.$mlProxy.execute("relatedList", {
+      "unitName": unitName,
       "scope": scope,
       "name": name,
       "uri": uri,
@@ -616,6 +640,7 @@ class Lux {
   }
   /**
   * Invokes the search operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype,
   * @param {string} q - provides an input value of the string datatype,
   * @param {string} [scope] - provides an input value of the string datatype,
   * @param {boolean|string} [mayChangeScope] - provides an input value of the boolean datatype,
@@ -628,8 +653,9 @@ class Lux {
   * @param {boolean|string} [synonymsEnabled] - provides an input value of the boolean datatype
   * @returns {Promise} object value of the jsonDocument data type
   */
-  search(q, scope, mayChangeScope, page, pageLength, pageWith, sort, filterResults, facetsSoon, synonymsEnabled) {
+  search(unitName, q, scope, mayChangeScope, page, pageLength, pageWith, sort, filterResults, facetsSoon, synonymsEnabled) {
     return this.$mlProxy.execute("search", {
+      "unitName": unitName,
       "q": q,
       "scope": scope,
       "mayChangeScope": mayChangeScope,
@@ -644,39 +670,49 @@ class Lux {
   }
   /**
   * Invokes the searchEstimate operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype,
   * @param {array|Buffer|Map|Set|stream.Readable|string} q - provides an input value of the jsonDocument datatype,
   * @param {string} [scope] - provides an input value of the string datatype
   * @returns {Promise} object value of the jsonDocument data type
   */
-  searchEstimate(q, scope) {
+  searchEstimate(unitName, q, scope) {
     return this.$mlProxy.execute("searchEstimate", {
+      "unitName": unitName,
       "q": q,
       "scope": scope
     }, arguments.length);
   }
   /**
   * Invokes the searchInfo operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype
   * @returns {Promise} object value of the jsonDocument data type
   */
-  searchInfo() {
-    return this.$mlProxy.execute("searchInfo", {}, arguments.length);
+  searchInfo(unitName) {
+    return this.$mlProxy.execute("searchInfo", {
+      "unitName": unitName
+    }, arguments.length);
   }
   /**
   * Invokes the searchWillMatch operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype,
   * @param {array|Buffer|Map|Set|stream.Readable|string} q - provides an input value of the jsonDocument datatype
   * @returns {Promise} object value of the jsonDocument data type
   */
-  searchWillMatch(q) {
+  searchWillMatch(unitName, q) {
     return this.$mlProxy.execute("searchWillMatch", {
+      "unitName": unitName,
       "q": q
     }, arguments.length);
   }
   /**
   * Invokes the stats operation on the database server.
+  * @param {string} [unitName] - provides an input value of the string datatype
   * @returns {Promise} object value of the jsonDocument data type
   */
-  stats() {
-    return this.$mlProxy.execute("stats", {}, arguments.length);
+  stats(unitName) {
+    return this.$mlProxy.execute("stats", {
+      "unitName": unitName
+    }, arguments.length);
   }
   /**
   * Invokes the storageInfo operation on the database server.

--- a/lib/ml-proxy.js
+++ b/lib/ml-proxy.js
@@ -1,10 +1,12 @@
 import Lux from './ml-generated/lux.cjs'
+import Document from './ml-generated/document.cjs'
 
 // A mediator between the application and the auto-generated MarkLogic client code
 class MLProxy {
   constructor(mlClient) {
     this.db = mlClient
-    this.luxInstance = Lux.on(this.db)
+    this.rootServices = Lux.on(this.db)
+    this.documentServices = Document.on(this.db)
   }
 
   static parseError(err) {
@@ -23,7 +25,7 @@ class MLProxy {
   }
 
   advancedSearchConfig() {
-    return this.luxInstance.advancedSearchConfig()
+    return this.rootServices.advancedSearchConfig()
   }
 
   autoComplete(
@@ -38,7 +40,7 @@ class MLProxy {
     previouslyFiltered,
     timeoutInMilliseconds,
   ) {
-    return this.luxInstance.autoComplete(
+    return this.rootServices.autoComplete(
       text,
       context,
       fullyHonorContext,
@@ -53,11 +55,11 @@ class MLProxy {
   }
 
   getDocument(uri, profile, lang) {
-    return this.luxInstance.document(uri, profile, lang)
+    return this.documentServices.read(uri, profile, lang)
   }
 
   facets(name, q, scope, page, pageLength, sort) {
-    return this.luxInstance.facets(
+    return this.rootServices.facets(
       name || null,
       q || null,
       scope || null,
@@ -68,7 +70,7 @@ class MLProxy {
   }
 
   relatedList(scope, name, uri, page, pageLength, relationshipsPerRelation) {
-    return this.luxInstance.relatedList(
+    return this.rootServices.relatedList(
       scope,
       name,
       uri,
@@ -89,7 +91,7 @@ class MLProxy {
     facetsSoon,
     synonymsEnabled,
   ) {
-    return this.luxInstance.search(
+    return this.rootServices.search(
       q,
       scope,
       mayChangeScope,
@@ -103,27 +105,27 @@ class MLProxy {
   }
 
   searchEstimate(q, scope) {
-    return this.luxInstance.searchEstimate(q, scope)
+    return this.rootServices.searchEstimate(q, scope)
   }
 
   searchInfo() {
-    return this.luxInstance.searchInfo()
+    return this.rootServices.searchInfo()
   }
 
   searchWillMatch(q) {
-    return this.luxInstance.searchWillMatch(q)
+    return this.rootServices.searchWillMatch(q)
   }
 
   stats() {
-    return this.luxInstance.stats()
+    return this.rootServices.stats()
   }
 
   translate(q, scope) {
-    return this.luxInstance.translate(q, scope)
+    return this.rootServices.translate(q, scope)
   }
 
   versionInfo() {
-    return this.luxInstance.versionInfo()
+    return this.rootServices.versionInfo()
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.30.0",
     "gulp": "^4.0.2",
+    "gulp-rename": "^2.0.0",
     "jest": "^27.3.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
This PR addresses a backwards-incompatible change made in the backend #163: the endpoint path for retrieving a document changed from /ds/lux/document.mjs to /ds/lux/document/read.mjs.

It does so with a second generated proxy class for a subset of the backend endpoints: the document CRUD endpoints.

There was a complication.  Here's what went down:

1. The `generate` function provided by the MarkLogic Node.js Client API (https://www.npmjs.com/package/marklogic) appears to have a sub-directory limitation*.
2. Up to now, all LUX data services have been directly within /lux-marklogic/src/main/ml-modules/root/ds/lux.
3. We added a "document" sub-directory, with additional data services.
4. We couldn't get the generator to pick up on the sub-directory.
5. It looked like we had three choices: maintain a single directory, move the document directory up a level (it is then picked up), or call `generate` a second time.
6. We chose the third option as it allows us to keep the deeper pathing we wanted: /ds/lux/document/create.mjs (vs. /ds/lux/documentCreate.mjs or /ds/document/create.mjs).
7. **But**, a second artifact produced by `generate` imposes on the middle tier. Thankfully, the middle tier already abstracts the generated code from the rest of the middle tier: ml-proxy.js. As such, ml-proxy.js imports both generated classes and continue to offer a single set of functions the rest of the middle tier can use to interact with MarkLogic --unaware of these details.

\* proxy-generator.js' readDirectory only processes items that have particular file extensions.