### PR TITLE
#170: start passing a value for the filterResults parameter to the backend's search and relatedList endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ---
 ## Unreleased
 - Added HAL links for Collection tabs and accordions on People and Group pages ([#141](https://github.com/project-lux/lux-middletier/issues/141)).
+- Added support for the filterResults parameter to the search and related list endpoints, correcting a bug introduced in 1.2.9 whereby results were no longer filtered ([#170](https://github.com/project-lux/lux-middletier/issues/170)). The search endpoint also now supports the mayChangeScope parameter, which was previously hard coded to false and still defaults to false.
 
 ## 1.2.9
 - Changed path to backend Read Document endpoint ([#163](https://github.com/project-lux/lux-middletier/issues/163)).

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -8,13 +8,25 @@
 
 ### Search and Helpers
 
-- [Search](#search)
-- [Related List](#related-list)
-- [Search Estimate](#search-estimate)
-- [Search Will Match](#search-will-match)
-- [Facets](#facets)
-- [Auto Complete](#auto-complete)
-- [Translate](#translate)
+- [API Endpoints](#api-endpoints)
+  - [Table of Contents](#table-of-contents)
+    - [Single Document](#single-document)
+    - [Search and Helpers](#search-and-helpers)
+    - [Configuration](#configuration)
+    - [System](#system)
+  - [Advanced Search Config](#advanced-search-config)
+  - [Auto Complete](#auto-complete)
+  - [Facets](#facets)
+  - [Related List](#related-list)
+  - [Search](#search)
+  - [Search Estimate](#search-estimate)
+  - [Search Info](#search-info)
+  - [Search Will Match](#search-will-match)
+  - [Stats](#stats)
+  - [Translate](#translate)
+  - [\_info](#_info)
+  - [Document](#document)
+  - [Health](#health)
 
 ### Configuration
 
@@ -26,13 +38,6 @@
 - [Stats](#stats)
 - [Health](#health)
 - [_info](#_info)
-
-### Deprecated
-
-- [Concept Hierarchy](#concept-hierarchy)
-- [Place Hierarchy](#place-hierarchy)
-- [Set Hierarchy](#set-hierarchy)
-- [Data Constants](#data-constants)
 
 ---
 
@@ -53,16 +58,6 @@ Returns configurations that inform the frontend to build the advanced search UI,
 - See [backend documentation](https://github.com/project-lux/lux-marklogic/blob/main/docs/lux-backend-api-usage.md#auto-complete) for detailed descriptions of input parameters and responses.
 - Example: https://lux.collections.yale.edu/api/auto-complete?text=oil&context=item.material
 
-## Data Constants
-(Deprecated)
-Returns mappings of names to URIs for key concepts so that the frontend code using the constant names will be simpler and more robust against changes.
-
-- URL: /api/data-constants
-- Method: GET
-- Query parameters: None
-- See [backend documentation](https://github.com/project-lux/lux-marklogic/blob/main/docs/lux-backend-api-usage.md#data-constants) for detailed descriptions of output format.
-- Example: https://lux.collections.yale.edu/api/data-constants
-
 ## Facets
 Provides facets.
 
@@ -78,7 +73,7 @@ Returns items related to the specified entity (document).
 - Method: GET
 - Query parameters:
   - Required: name, uri
-  - Optional: page, pageLength, relationshipsPerRelation
+  - Optional: page, pageLength, filterResults, relationshipsPerRelation
 - See [backend documentation](https://github.com/project-lux/lux-marklogic/blob/main/docs/lux-backend-api-usage.md#related-list) for detailed descriptions of parameters and responses.
 - Example: https://lux.collections.yale.edu/api/related-list?scope=agent&name=relatedToAgent&uri=https%3A%2F%2Flux.collections.yale.edu%2Fdata%2Fperson%2F783e7e6f-6863-4978-8aa3-9e6cd8cd8e83
 
@@ -90,9 +85,9 @@ The primary means to search LUX's backend.
 - Query parameters:
   - Required:
     - q - query in JSON search format defined by the backend
-  - Optional:  page, pageLength, sort, facetNames, facetsOnly, facetsSoon, synonymsEnabled, mayChangeScope
+  - Optional: mayChangeScope, page, pageLength, pageWith, sort, filterResults, facetsSoon, synonymsEnabled
 - See [backend documentation](https://github.com/project-lux/lux-marklogic/blob/main/docs/lux-backend-api-usage.md#search) for detailed descriptions of parameters and responses.
-- Example: https://lux.collections.yale.edu/api/search?q=%7B%22AND%22%3A%5B%7B%22text%22%3A%22any%22%2C%22_lang%22%3A%22en%22%7D%2C%7B%22text%22%3A%22warhol%22%2C%22_lang%22%3A%22en%22%7D%5D%7D&scope=item&page=1&sort
+- Example: https://lux.collections.yale.edu/api/search?q=%7B%22AND%22%3A%5B%7B%22text%22%3A%22any%22%2C%22_lang%22%3A%22en%22%7D%2C%7B%22text%22%3A%22warhol%22%2C%22_lang%22%3A%22en%22%7D%5D%7D&scope=item&page=1
 
 ## Search Estimate
 Returns estimated number of results for a search.

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,4 +53,4 @@ Which will update the file  `./lib/ml-generated/lux.js`.
 
 ## Docker
 
-To get an idea for building  a docker image and running it, see [Dockerfile](../docker/Dockerfile), [build-docker-image.sh](../docker/build-docker-image.sh), and [run-docker-container.sh](../docker/run-docker-container.sh) in the [/docker](../docker) directory for an example.
+To get an idea for building a docker image and running it, see [Dockerfile](../docker/Dockerfile), [build-docker-image.sh](../docker/build-docker-image.sh), and [run-docker-container.sh](../docker/run-docker-container.sh) in the [/docker](../docker) directory for an example.

--- a/lib/ml-proxy.js
+++ b/lib/ml-proxy.js
@@ -106,39 +106,51 @@ class MLProxy {
     )
   }
 
-  relatedList(unitName, scope, name, uri, page, pageLength, relationshipsPerRelation) {
+  relatedList({
+    unitName,
+    searchScopeName,
+    relatedListName,
+    uri,
+    page = 1,
+    pageLength = 100,
+    filterResults = true,
+    relationshipsPerRelation = 100000,
+  }) {
     return this.rootServices.relatedList(
       unitName,
-      scope,
-      name,
+      searchScopeName,
+      relatedListName,
       uri,
       page,
       pageLength,
+      filterResults,
       relationshipsPerRelation,
     )
   }
 
-  search(
+  search({
     unitName,
-    q,
-    scope,
-    mayChangeScope,
-    page,
-    pageLength,
-    pageWith,
-    sort,
-    facetsSoon,
-    synonymsEnabled,
-  ) {
+    searchCriteria,
+    searchScope,
+    mayChangeScope = false,
+    page = 1,
+    pageLength = 20,
+    pageWith = '',
+    sortDelimitedStr = '',
+    filterResults = true,
+    facetsSoon = false,
+    synonymsEnabled = false,
+  }) {
     return this.rootServices.search(
       unitName,
-      q,
-      scope,
+      searchCriteria,
+      searchScope,
       mayChangeScope,
       page,
       pageLength,
       pageWith,
-      sort,
+      sortDelimitedStr,
+      filterResults,
       facetsSoon,
       synonymsEnabled,
     )


### PR DESCRIPTION
1. Proxy passes the filterResults parameter to the search and relatedList backend endpoints, fixing the main issue.
2. Added the parameter to the middle tier endpoints.  Defaults to true.
3. The search endpoint now also supports the mayChangeScope parameter.  Defaults to false, which is what it was hardcoded as.
4. The middle tier's proxy for the backend search and relatedList endpoints now accepts an object, where the top-level properties correspond to the endpoints' parameters.  This makes the proxy exclusively responsible for the parameter order.  Over time, I'd like to do this for the other endpoints.  At some point, the backend endpoints should also switch to the same approach.
5. For these two endpoints, I updated MT variable names to align with the backend endpoint parameter names.  I did _not_ change the MT endpoint parameter names.
6. Three calls to search and one to relatedList were updated.

I'm not enthusiastic about having three different ways to default a boolean parameter value.  Below are the three types, which may be found in handleSearch.  Perhaps we can introduce the likes of getBoolean(value, defaultValue), like getNumArg.

```javascript
    // Approach 1 when false is the desired default.
    const mayChangeScope = req.query.mayChangeScope === 'true' // default to false

    // Approach 2 when true is the desired default.
    const filterResults = req.query.filterResults === undefined // default to true
      || req.query.filterResults === ''
      || req.query.filterResults === 'true'

    // Approach 3 which was existing logic.
    const facetsSoon = req.query.facetsSoon === ''
      || req.query.facetsSoon === 'true'
```